### PR TITLE
fix: 🐛 adjust margin-top for the side menu from 50px to 2px

### DIFF
--- a/iadapter-applications/libs/hdu-api-nav-menu/src/lib/hdu-api-nav-menu/hdu-api-nav-menu.component.html
+++ b/iadapter-applications/libs/hdu-api-nav-menu/src/lib/hdu-api-nav-menu/hdu-api-nav-menu.component.html
@@ -1,4 +1,4 @@
-<ul nz-menu nzMode="inline" style="margin-top: 50px">
+<ul nz-menu nzMode="inline" style="margin-top: 2px">
   <ng-container *ngFor="let menu of menus">
     <li
       *ngIf="!menu?.subMenus"


### PR DESCRIPTION
This commit will adjust margin-top for the side menu from 50ox to 2px for visibility and for improved UI/UX